### PR TITLE
Fix bugs that cause the script to fail

### DIFF
--- a/src/chunkify.coffee
+++ b/src/chunkify.coffee
@@ -11,12 +11,10 @@
 #   chen-ye
 
 maxLength = process.env.HUBOT_CHUNKIFY_MAX or 320
-chunkExp = new RegExp('.{1,' + HUBOT_CHUNKIFY_MAX + '}', 'g')
 
 module.exports = (robot) ->
         
     _chunkify = (string, newstrings) ->
-        newstrings = []
         if(string.length > maxLength)
           while string.length > 0
             # Split message at last line break, if it exists


### PR DESCRIPTION
Previously, the script was failing and Hubot would produce no output.
* Removed old regular expression that references the now undeclared variable HUBOT_CHUNKIFY_MAX
* Removed assignment of empty array to newstrings, since this needs to keep track of results for old context strings
* Add newline to end of file